### PR TITLE
Port AMBA to standalone diplomacy

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -93,12 +93,12 @@ trait Diplomacy
   override def millSourcePath = os.pwd / "dependencies" / "diplomacy" / "diplomacy"
 
   // dont use chisel from source
-  def chiselModule    = None
-  def chiselPluginJar = None
+  def chiselModule = Option.when(crossValue == "source")(chisel)
+  def chiselPluginJar = T(Option.when(crossValue == "source")(chisel.pluginModule.jar()))
 
   // use chisel from ivy
-  def chiselIvy       = Some(v.chiselCrossVersions(crossValue)._1)
-  def chiselPluginIvy = Some(v.chiselCrossVersions(crossValue)._2)
+  def chiselIvy = Option.when(crossValue != "source")(v.chiselCrossVersions(crossValue)._1)
+  def chiselPluginIvy = Option.when(crossValue != "source")(v.chiselCrossVersions(crossValue)._2)
 
   // use CDE from source until published to sonatype
   def cdeModule = cde

--- a/src/main/scala/amba/ahb/AHBLite.scala
+++ b/src/main/scala/amba/ahb/AHBLite.scala
@@ -4,7 +4,7 @@ package freechips.rocketchip.amba.ahb
 
 import chisel3._
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
 
 class AHBLite()(implicit p: Parameters) extends LazyModule {
   val node = AHBMasterAdapterNode(

--- a/src/main/scala/amba/ahb/Nodes.scala
+++ b/src/main/scala/amba/ahb/Nodes.scala
@@ -4,8 +4,11 @@ package freechips.rocketchip.amba.ahb
 
 import chisel3._
 import chisel3.experimental.SourceInfo
+
 import org.chipsalliance.cde.config.{Parameters, Field}
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.diplomacy.ValName
+import org.chipsalliance.diplomacy.nodes.{SimpleNodeImp, RenderedEdge, OutwardNode, InwardNode, SourceNode, SinkNode, IdentityNode, AdapterNode, MixedNexusNode, NexusNode}
 
 case object AHBSlaveMonitorBuilder extends Field[AHBSlaveMonitorArgs => AHBSlaveMonitorBase]
 

--- a/src/main/scala/amba/ahb/Parameters.scala
+++ b/src/main/scala/amba/ahb/Parameters.scala
@@ -2,11 +2,16 @@
 
 package freechips.rocketchip.amba.ahb
 
-import chisel3.util._
 import chisel3.experimental.SourceInfo
+import chisel3.util._
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
+
+import org.chipsalliance.diplomacy.nodes.BaseNode
+
+import freechips.rocketchip.diplomacy.{AddressSet, Resource, RegionType, TransferSizes, Device, ResourceAddress, ResourcePermissions}
+import freechips.rocketchip.util.{BundleField, BundleFieldBase, BundleKeyBase}
+
 import scala.math.{max, min}
 
 case class AHBSlaveParameters(

--- a/src/main/scala/amba/ahb/RegisterRouter.scala
+++ b/src/main/scala/amba/ahb/RegisterRouter.scala
@@ -3,12 +3,18 @@
 package freechips.rocketchip.amba.ahb
 
 import chisel3._
-import chisel3.util._
+import chisel3.util.{log2Up, log2Ceil, Decoupled}
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.regmapper._
+
+import org.chipsalliance.diplomacy.ValName
+import org.chipsalliance.diplomacy.nodes.{SinkNode}
+
+import freechips.rocketchip.diplomacy.{AddressSet, TransferSizes}
+import freechips.rocketchip.regmapper.{RegMapperParams, RegField, RegMapperInput, RegisterRouter, RegMapper}
 import freechips.rocketchip.interrupts.{IntSourceNode, IntSourcePortSimple}
-import freechips.rocketchip.util._
+import freechips.rocketchip.util.MaskGen
+
 import scala.math.min
 
 case class AHBRegisterNode(address: AddressSet, concurrency: Int = 0, beatBytes: Int = 4, undefZero: Boolean = true, executable: Boolean = false)(implicit valName: ValName)

--- a/src/main/scala/amba/ahb/SRAM.scala
+++ b/src/main/scala/amba/ahb/SRAM.scala
@@ -5,9 +5,11 @@ package freechips.rocketchip.amba.ahb
 import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
+
+import freechips.rocketchip.diplomacy.{AddressSet, DiplomaticSRAM, HasJustOneSeqMem, RegionType, TransferSizes}
 import freechips.rocketchip.tilelink.LFSRNoiseMaker
+import freechips.rocketchip.util.{MaskGen, DataToAugmentedData, SeqMemToAugmentedSeqMem, PlusArg}
 
 class AHBRAM(
     address: AddressSet,

--- a/src/main/scala/amba/ahb/Test.scala
+++ b/src/main/scala/amba/ahb/Test.scala
@@ -3,12 +3,16 @@
 package freechips.rocketchip.amba.ahb
 
 import chisel3._
+
 import org.chipsalliance.cde.config.Parameters
+
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp, SimpleLazyModule}
+
 import freechips.rocketchip.devices.tilelink.TLTestRAM
-import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.diplomacy.{AddressSet, BufferParams}
 import freechips.rocketchip.regmapper.{RRTest0, RRTest1}
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.unittest._
+import freechips.rocketchip.tilelink.{TLFuzzer, TLRAMModel, TLToAHB, TLDelayer, TLBuffer, TLErrorEvaluator, TLFragmenter}
+import freechips.rocketchip.unittest.{UnitTestModule, UnitTest}
 
 class AHBRRTest0(address: BigInt)(implicit p: Parameters)
   extends RRTest0(address)

--- a/src/main/scala/amba/ahb/ToTL.scala
+++ b/src/main/scala/amba/ahb/ToTL.scala
@@ -4,11 +4,17 @@ package freechips.rocketchip.amba.ahb
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.amba._
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
+
+import org.chipsalliance.diplomacy.ValName
+import org.chipsalliance.diplomacy.nodes.{MixedAdapterNode}
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
+
+import freechips.rocketchip.amba.{AMBAProtField, AMBAProt}
+import freechips.rocketchip.diplomacy.TransferSizes
+import freechips.rocketchip.tilelink.{TLImp, TLMasterPortParameters, TLMessages, TLMasterParameters, TLMasterToSlaveTransferSizes}
+import freechips.rocketchip.util.{BundleMap, MaskGen, DataToAugmentedData}
 
 case class AHBToTLNode()(implicit valName: ValName) extends MixedAdapterNode(AHBImpSlave, TLImp)(
   dFn = { case mp =>

--- a/src/main/scala/amba/ahb/Xbar.scala
+++ b/src/main/scala/amba/ahb/Xbar.scala
@@ -3,10 +3,14 @@
 package freechips.rocketchip.amba.ahb
 
 import chisel3._
-import chisel3.util._
+import chisel3.util.Mux1H
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
+
+import freechips.rocketchip.diplomacy.AddressDecoder
+import freechips.rocketchip.util.BundleField
+
 
 class AHBFanout()(implicit p: Parameters) extends LazyModule {
   val node = new AHBFanoutNode(

--- a/src/main/scala/amba/ahb/package.scala
+++ b/src/main/scala/amba/ahb/package.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.amba
 
-import freechips.rocketchip.diplomacy._
+import org.chipsalliance.diplomacy.nodes.{InwardNodeHandle, OutwardNodeHandle, SimpleNodeHandle}
 
 package object ahb
 {

--- a/src/main/scala/amba/apb/Nodes.scala
+++ b/src/main/scala/amba/apb/Nodes.scala
@@ -4,8 +4,11 @@ package freechips.rocketchip.amba.apb
 
 import chisel3._
 import chisel3.experimental.SourceInfo
+
 import org.chipsalliance.cde.config.{Parameters, Field}
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.diplomacy.ValName
+import org.chipsalliance.diplomacy.nodes.{SimpleNodeImp,RenderedEdge, InwardNode, OutwardNode, SourceNode, SinkNode, NexusNode, IdentityNode}
 
 case object APBMonitorBuilder extends Field[APBMonitorArgs => APBMonitorBase]
 

--- a/src/main/scala/amba/apb/Parameters.scala
+++ b/src/main/scala/amba/apb/Parameters.scala
@@ -2,11 +2,17 @@
 
 package freechips.rocketchip.amba.apb
 
-import chisel3.util._
+import chisel3.util.{isPow2, log2Up}
 import chisel3.experimental.SourceInfo
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
+
+import org.chipsalliance.diplomacy.nodes.BaseNode
+
+import freechips.rocketchip.diplomacy.{AddressSet, Resource, Device, RegionType, ResourceAddress, ResourcePermissions}
+
+import freechips.rocketchip.util.{BundleField, BundleKeyBase, BundleFieldBase}
+
 import scala.math.max
 
 case class APBSlaveParameters(

--- a/src/main/scala/amba/apb/RegisterRouter.scala
+++ b/src/main/scala/amba/apb/RegisterRouter.scala
@@ -3,10 +3,15 @@
 package freechips.rocketchip.amba.apb
 
 import chisel3._
-import chisel3.util._
+import chisel3.util.{Decoupled, log2Up, log2Ceil}
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.regmapper._
+
+import org.chipsalliance.diplomacy.ValName
+import org.chipsalliance.diplomacy.nodes.SinkNode
+
+import freechips.rocketchip.diplomacy.AddressSet
+import freechips.rocketchip.regmapper.{RegField, RegMapperParams, RegMapperInput, RegMapper, RegisterRouter}
 import freechips.rocketchip.interrupts.{IntSourceNode, IntSourcePortSimple}
 
 case class APBRegisterNode(address: AddressSet, concurrency: Int = 0, beatBytes: Int = 4, undefZero: Boolean = true, executable: Boolean = false)(implicit valName: ValName)

--- a/src/main/scala/amba/apb/SRAM.scala
+++ b/src/main/scala/amba/apb/SRAM.scala
@@ -3,11 +3,15 @@
 package freechips.rocketchip.amba.apb
 
 import chisel3._
-import chisel3.util._
+import chisel3.util.{Cat, log2Ceil, RegEnable}
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
+
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
+
+import freechips.rocketchip.diplomacy.{AddressSet, DiplomaticSRAM, HasJustOneSeqMem, RegionType}
 import freechips.rocketchip.tilelink.LFSRNoiseMaker
+import freechips.rocketchip.util.SeqMemToAugmentedSeqMem
 
 class APBRAM(
     address: AddressSet,

--- a/src/main/scala/amba/apb/Test.scala
+++ b/src/main/scala/amba/apb/Test.scala
@@ -3,10 +3,14 @@
 package freechips.rocketchip.amba.apb
 
 import chisel3._
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
+
+import freechips.rocketchip.diplomacy.{BufferParams, AddressSet}
 import freechips.rocketchip.regmapper.{RRTest0, RRTest1}
-import freechips.rocketchip.tilelink._
+import freechips.rocketchip.tilelink.{TLFuzzer, TLRAMModel, TLToAPB, TLDelayer, TLBuffer, TLFragmenter}
 import freechips.rocketchip.unittest._
 
 class APBRRTest0(address: BigInt)(implicit p: Parameters) 

--- a/src/main/scala/amba/apb/ToTL.scala
+++ b/src/main/scala/amba/apb/ToTL.scala
@@ -4,11 +4,16 @@ package freechips.rocketchip.amba.apb
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.amba._
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
+
+import org.chipsalliance.diplomacy.ValName
+import org.chipsalliance.diplomacy.nodes.{MixedAdapterNode}
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
+
+import freechips.rocketchip.amba.{AMBAProt, AMBAProtField}
+import freechips.rocketchip.diplomacy.TransferSizes
+import freechips.rocketchip.tilelink.{TLImp, TLMessages, TLMasterPortParameters, TLMasterParameters}
 
 case class APBToTLNode()(implicit valName: ValName) extends MixedAdapterNode(APBImp, TLImp)(
   dFn = { mp =>

--- a/src/main/scala/amba/apb/Xbar.scala
+++ b/src/main/scala/amba/apb/Xbar.scala
@@ -3,10 +3,14 @@
 package freechips.rocketchip.amba.apb
 
 import chisel3._
-import chisel3.util._
+import chisel3.util.Mux1H
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
+
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
+
+import freechips.rocketchip.diplomacy.AddressDecoder
+import freechips.rocketchip.util.BundleField
 
 class APBFanout()(implicit p: Parameters) extends LazyModule {
   val node = new APBNexusNode(

--- a/src/main/scala/amba/apb/package.scala
+++ b/src/main/scala/amba/apb/package.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.amba
 
-import freechips.rocketchip.diplomacy._
+import org.chipsalliance.diplomacy.nodes.{InwardNodeHandle, OutwardNodeHandle, SimpleNodeHandle}
 
 package object apb
 {

--- a/src/main/scala/amba/axi4/AsyncCrossing.scala
+++ b/src/main/scala/amba/axi4/AsyncCrossing.scala
@@ -3,11 +3,16 @@
 package freechips.rocketchip.amba.axi4
 
 import chisel3._
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
+
+import org.chipsalliance.diplomacy.nodes.{NodeHandle}
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
+
+import freechips.rocketchip.diplomacy.{AddressSet, AsynchronousCrossing}
+import freechips.rocketchip.tilelink.{TLRAMModel, TLFuzzer, TLToAXI4}
 import freechips.rocketchip.subsystem.CrossingWrapper
-import freechips.rocketchip.util._
+import freechips.rocketchip.util.{ToAsyncBundle, FromAsyncBundle, AsyncQueueParams, Pow2ClockDivider}
 
 /**
   * Source(Master) side for AXI4 crossing clock domain

--- a/src/main/scala/amba/axi4/Buffer.scala
+++ b/src/main/scala/amba/axi4/Buffer.scala
@@ -4,8 +4,13 @@ package freechips.rocketchip.amba.axi4
 
 import chisel3._
 import chisel3.util.{Queue, IrrevocableIO}
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
+
+import freechips.rocketchip.diplomacy.BufferParams
+
 import scala.math.min
 
 /**

--- a/src/main/scala/amba/axi4/Credited.scala
+++ b/src/main/scala/amba/axi4/Credited.scala
@@ -3,10 +3,14 @@
 package freechips.rocketchip.amba.axi4
 
 import chisel3._
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
+
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
+
+import freechips.rocketchip.diplomacy.{AddressSet, CreditedCrossing}
 import freechips.rocketchip.subsystem.CrossingWrapper
+import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 
 class AXI4CreditedBuffer(delay: AXI4CreditedDelay)(implicit p: Parameters) extends LazyModule

--- a/src/main/scala/amba/axi4/CrossingHelper.scala
+++ b/src/main/scala/amba/axi4/CrossingHelper.scala
@@ -3,7 +3,9 @@
 package freechips.rocketchip.amba.axi4
 
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+import org.chipsalliance.diplomacy.lazymodule.{LazyScope}
+
+import freechips.rocketchip.diplomacy.{CrossingType, ClockCrossingType, NoCrossing, AsynchronousCrossing, RationalCrossing, SynchronousCrossing, CreditedCrossing}
 import freechips.rocketchip.prci.{ResetCrossingType, NoResetCrossing, StretchedResetCrossing}
 
 trait AXI4OutwardCrossingHelper {

--- a/src/main/scala/amba/axi4/Deinterleaver.scala
+++ b/src/main/scala/amba/axi4/Deinterleaver.scala
@@ -5,8 +5,12 @@ package freechips.rocketchip.amba.axi4
 import chisel3._
 import chisel3.util.{Cat, isPow2, log2Ceil, ReadyValidIO,
   log2Up, OHToUInt, Queue, QueueIO, UIntToOH}
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
+
+import freechips.rocketchip.diplomacy.{BufferParams, TransferSizes}
 import freechips.rocketchip.util.leftOR
 
 /** This adapter deinterleaves read responses on the R channel.

--- a/src/main/scala/amba/axi4/Delayer.scala
+++ b/src/main/scala/amba/axi4/Delayer.scala
@@ -3,9 +3,12 @@
 package freechips.rocketchip.amba.axi4
 
 import chisel3._
-import chisel3.util._
+import chisel3.util.IrrevocableIO
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
+
 import freechips.rocketchip.tilelink.LFSRNoiseMaker
 
 /**

--- a/src/main/scala/amba/axi4/Filter.scala
+++ b/src/main/scala/amba/axi4/Filter.scala
@@ -2,8 +2,11 @@
 
 package freechips.rocketchip.amba.axi4
 
-import org.chipsalliance.cde.config._
-import freechips.rocketchip.diplomacy._
+import org.chipsalliance.cde.config.Parameters
+
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
+
+import freechips.rocketchip.diplomacy.{AddressSet, TransferSizes}
 
 class AXI4Filter(
   Sfilter: AXI4SlaveParameters  => Option[AXI4SlaveParameters]   = AXI4Filter.Sidentity,

--- a/src/main/scala/amba/axi4/Fragmenter.scala
+++ b/src/main/scala/amba/axi4/Fragmenter.scala
@@ -3,10 +3,14 @@
 package freechips.rocketchip.amba.axi4
 
 import chisel3._
-import chisel3.util._
+import chisel3.util.{Mux1H, Queue, IrrevocableIO, log2Ceil, UIntToOH}
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
+
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
+
+import freechips.rocketchip.diplomacy.{AddressDecoder, AddressSet, TransferSizes}
+import freechips.rocketchip.util.{ControlKey, SimpleBundleField, rightOR, leftOR, OH1ToOH, UIntToOH1}
 
 case object AXI4FragLast extends ControlKey[Bool]("real_last")
 case class AXI4FragLastField() extends SimpleBundleField(AXI4FragLast)(Output(Bool()), false.B)

--- a/src/main/scala/amba/axi4/IdIndexer.scala
+++ b/src/main/scala/amba/axi4/IdIndexer.scala
@@ -3,10 +3,13 @@
 package freechips.rocketchip.amba.axi4
 
 import chisel3._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
 import chisel3.util.{log2Ceil, Cat}
+
+import org.chipsalliance.cde.config.Parameters
+
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
+
+import freechips.rocketchip.util.{ControlKey, SimpleBundleField}
 
 case object AXI4ExtraId extends ControlKey[UInt]("extra_id")
 case class AXI4ExtraIdField(width: Int) extends SimpleBundleField(AXI4ExtraId)(Output(UInt(width.W)), 0.U)

--- a/src/main/scala/amba/axi4/Nodes.scala
+++ b/src/main/scala/amba/axi4/Nodes.scala
@@ -4,8 +4,12 @@ package freechips.rocketchip.amba.axi4
 
 import chisel3._
 import chisel3.experimental.SourceInfo
+
 import org.chipsalliance.cde.config.{Parameters, Field}
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.diplomacy.ValName
+import org.chipsalliance.diplomacy.nodes.{SimpleNodeImp, RenderedEdge, OutwardNode, InwardNode, SourceNode, SinkNode, NexusNode, AdapterNode, IdentityNode, MixedAdapterNode}
+
 import freechips.rocketchip.util.AsyncQueueParams
 
 case object AXI4MonitorBuilder extends Field[AXI4MonitorArgs => AXI4MonitorBase]

--- a/src/main/scala/amba/axi4/Parameters.scala
+++ b/src/main/scala/amba/axi4/Parameters.scala
@@ -3,11 +3,16 @@
 package freechips.rocketchip.amba.axi4
 
 import chisel3.experimental.SourceInfo
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
-import scala.math.max
 import chisel3.util.{isPow2, log2Up}
+
+import org.chipsalliance.cde.config.Parameters
+
+import org.chipsalliance.diplomacy.nodes.BaseNode
+
+import freechips.rocketchip.diplomacy.{AddressSet, Resource, RegionType, TransferSizes, Device, ResourceAddress, ResourcePermissions, IdRange, BufferParams, IdMap, IdMapEntry, DirectedBuffers}
+import freechips.rocketchip.util.{BundleField, BundleFieldBase, BundleKeyBase, AsyncQueueParams, CreditedDelay}
+
+import scala.math.max
 
 /**
   * Parameters for AXI4 slave

--- a/src/main/scala/amba/axi4/RegisterRouter.scala
+++ b/src/main/scala/amba/axi4/RegisterRouter.scala
@@ -3,10 +3,15 @@
 package freechips.rocketchip.amba.axi4
 
 import chisel3._
-import chisel3.util._
+import chisel3.util.{Decoupled, Queue, log2Ceil, log2Up}
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.regmapper._
+
+import org.chipsalliance.diplomacy.ValName
+import org.chipsalliance.diplomacy.nodes.{SinkNode}
+
+import freechips.rocketchip.diplomacy.{AddressSet, NoCrossing, TransferSizes}
+import freechips.rocketchip.regmapper.{RegField, RegMapper, RegMapperInput, RegMapperParams, RegisterRouter}
 import freechips.rocketchip.interrupts.{IntSourceNode, IntSourcePortSimple}
 import freechips.rocketchip.util._
 

--- a/src/main/scala/amba/axi4/SRAM.scala
+++ b/src/main/scala/amba/axi4/SRAM.scala
@@ -3,11 +3,15 @@
 package freechips.rocketchip.amba.axi4
 
 import chisel3._
-import chisel3.util._
+import chisel3.util.{Cat, log2Ceil}
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
-import freechips.rocketchip.amba._
+
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
+
+import freechips.rocketchip.amba.AMBACorrupt
+import freechips.rocketchip.diplomacy.{AddressSet, DiplomaticSRAM, HasJustOneSeqMem, RegionType, TransferSizes}
+import freechips.rocketchip.util.{BundleMap, SeqMemToAugmentedSeqMem}
 
 /**
   * AXI4 slave device to provide a RAM storage

--- a/src/main/scala/amba/axi4/Test.scala
+++ b/src/main/scala/amba/axi4/Test.scala
@@ -3,9 +3,13 @@
 package freechips.rocketchip.amba.axi4
 
 import chisel3._
+
 import org.chipsalliance.cde.config.Parameters
+
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp, SimpleLazyModule}
+
 import freechips.rocketchip.devices.tilelink._
-import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.diplomacy.{AddressSet, BufferParams}
 import freechips.rocketchip.regmapper.{RRTest0, RRTest1}
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.unittest._

--- a/src/main/scala/amba/axi4/ToTL.scala
+++ b/src/main/scala/amba/axi4/ToTL.scala
@@ -3,12 +3,18 @@
 package freechips.rocketchip.amba.axi4
 
 import chisel3._
-import chisel3.util._
-import freechips.rocketchip.amba._
+import chisel3.util.{Cat, log2Up, log2Ceil, UIntToOH, Queue}
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
+
+import org.chipsalliance.diplomacy.ValName
+import org.chipsalliance.diplomacy.nodes.{MixedAdapterNode, InwardNodeImp}
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
+
+import freechips.rocketchip.amba.{AMBACorrupt, AMBAProt, AMBAProtField}
+import freechips.rocketchip.diplomacy.{IdRange, IdMapEntry, TransferSizes}
+import freechips.rocketchip.tilelink.{TLImp, TLMasterParameters, TLMasterPortParameters, TLArbiter}
+import freechips.rocketchip.util.{OH1ToUInt, UIntToOH1}
 
 case class AXI4ToTLIdMapEntry(tlId: IdRange, axi4Id: IdRange, name: String)
   extends IdMapEntry

--- a/src/main/scala/amba/axi4/UserYanker.scala
+++ b/src/main/scala/amba/axi4/UserYanker.scala
@@ -3,10 +3,13 @@
 package freechips.rocketchip.amba.axi4
 
 import chisel3._
-import chisel3.util._
+import chisel3.util.{Queue, QueueIO, UIntToOH}
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
+
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
+
+import freechips.rocketchip.util.BundleMap
 
 /** This adapter prunes all user bit fields of the echo type from request messages,
   * storing them in queues and echoing them back when matching response messages are received.

--- a/src/main/scala/amba/axi4/Xbar.scala
+++ b/src/main/scala/amba/axi4/Xbar.scala
@@ -3,12 +3,16 @@
 package freechips.rocketchip.amba.axi4
 
 import chisel3._
-import chisel3.util._
-import org.chipsalliance.cde.config._
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
-import freechips.rocketchip.unittest._
-import freechips.rocketchip.tilelink._
+import chisel3.util.{Cat, Queue, UIntToOH, log2Ceil, OHToUInt, Mux1H, IrrevocableIO}
+
+import org.chipsalliance.cde.config.Parameters
+
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
+
+import freechips.rocketchip.diplomacy.{AddressDecoder, AddressSet, BufferParams}
+import freechips.rocketchip.tilelink.{TLArbiter, TLXbar, TLFilter, TLFuzzer, TLToAXI4, TLRAMModel}
+import freechips.rocketchip.unittest.{UnitTest, UnitTestModule}
+import freechips.rocketchip.util.BundleField
 
 /**
   * AXI4 Crossbar. It connects multiple AXI4 masters to slaves.

--- a/src/main/scala/amba/axi4/package.scala
+++ b/src/main/scala/amba/axi4/package.scala
@@ -2,8 +2,11 @@
 
 package freechips.rocketchip.amba
 
-import freechips.rocketchip.diplomacy.{HasClockDomainCrossing, _}
-import freechips.rocketchip.prci.{HasResetDomainCrossing}
+import org.chipsalliance.diplomacy.ValName
+import org.chipsalliance.diplomacy.nodes.{SimpleNodeHandle, OutwardNodeHandle, InwardNodeHandle}
+
+import freechips.rocketchip.diplomacy.HasClockDomainCrossing
+import freechips.rocketchip.prci.HasResetDomainCrossing
 
 /**
   * Provide bundles, adapters and devices etc for AMBA AXI4 protocol.
@@ -15,15 +18,15 @@ package object axi4
   type AXI4InwardNode = InwardNodeHandle[AXI4MasterPortParameters, AXI4SlavePortParameters, AXI4EdgeParameters, AXI4Bundle]
 
   implicit class AXI4ClockDomainCrossing(private val x: HasClockDomainCrossing) extends AnyVal {
-    def crossIn (n: AXI4InwardNode) (implicit valName: ValName) = AXI4InwardClockCrossingHelper(valName.name, x, n)
-    def crossOut(n: AXI4OutwardNode)(implicit valName: ValName) = AXI4OutwardClockCrossingHelper(valName.name, x, n)
+    def crossIn (n: AXI4InwardNode) (implicit valName: ValName) = AXI4InwardClockCrossingHelper(valName.value, x, n)
+    def crossOut(n: AXI4OutwardNode)(implicit valName: ValName) = AXI4OutwardClockCrossingHelper(valName.value, x, n)
     def cross(n: AXI4InwardNode) (implicit valName: ValName) = crossIn(n)
     def cross(n: AXI4OutwardNode)(implicit valName: ValName) = crossOut(n)
   }
 
   implicit class AXI4ResetDomainCrossing(private val x: HasResetDomainCrossing) extends AnyVal {
-    def crossIn (n: AXI4InwardNode) (implicit valName: ValName) = AXI4InwardResetCrossingHelper(valName.name, x, n)
-    def crossOut(n: AXI4OutwardNode)(implicit valName: ValName) = AXI4OutwardResetCrossingHelper(valName.name, x, n)
+    def crossIn (n: AXI4InwardNode) (implicit valName: ValName) = AXI4InwardResetCrossingHelper(valName.value, x, n)
+    def crossOut(n: AXI4OutwardNode)(implicit valName: ValName) = AXI4OutwardResetCrossingHelper(valName.value, x, n)
     def cross(n: AXI4InwardNode) (implicit valName: ValName) = crossIn(n)
     def cross(n: AXI4OutwardNode)(implicit valName: ValName) = crossOut(n)
   }

--- a/src/main/scala/amba/axis/Buffer.scala
+++ b/src/main/scala/amba/axis/Buffer.scala
@@ -2,8 +2,10 @@
 
 package freechips.rocketchip.amba.axis
 
-import org.chipsalliance.cde.config._
-import freechips.rocketchip.diplomacy._
+import org.chipsalliance.cde.config.Parameters
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
+
+import freechips.rocketchip.diplomacy.BufferParams
 
 class AXISBuffer(val params: BufferParams)(implicit p: Parameters) extends LazyModule
 {

--- a/src/main/scala/amba/axis/Nodes.scala
+++ b/src/main/scala/amba/axis/Nodes.scala
@@ -3,8 +3,10 @@
 package freechips.rocketchip.amba.axis
 
 import chisel3.experimental.SourceInfo
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+import org.chipsalliance.diplomacy.ValName
+import org.chipsalliance.diplomacy.nodes.{SimpleNodeImp, SourceNode, SinkNode, NexusNode, AdapterNode, OutwardNode, IdentityNode, RenderedEdge, InwardNode}
 
 object AXISImp extends SimpleNodeImp[AXISMasterPortParameters, AXISSlavePortParameters, AXISEdgeParameters, AXISBundle]
 {

--- a/src/main/scala/amba/axis/Parameters.scala
+++ b/src/main/scala/amba/axis/Parameters.scala
@@ -1,11 +1,15 @@
 // See LICENSE.SiFive for license details.
 package freechips.rocketchip.amba.axis
 
-import chisel3.util._
 import chisel3.experimental.SourceInfo
+import chisel3.util.{isPow2, log2Ceil}
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.util._
-import freechips.rocketchip.diplomacy._
+import org.chipsalliance.diplomacy.nodes.BaseNode
+
+import freechips.rocketchip.diplomacy.{TransferSizes, Resource, IdRange}
+import freechips.rocketchip.util.{BundleFieldBase, BundleField}
+
 
 class AXISSlaveParameters private (
   val name:          String,

--- a/src/main/scala/amba/axis/Xbar.scala
+++ b/src/main/scala/amba/axis/Xbar.scala
@@ -3,10 +3,12 @@
 package freechips.rocketchip.amba.axis
 
 import chisel3._
-import chisel3.util._
-import org.chipsalliance.cde.config._
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
+import chisel3.util.{Cat, log2Ceil, Mux1H}
+
+import org.chipsalliance.cde.config.{Config, Parameters}
+import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
+
+import freechips.rocketchip.tilelink.{TLXbar, TLArbiter}
 
 class AXISXbar(beatBytes: Int, policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parameters) extends LazyModule
 {

--- a/src/main/scala/amba/axis/package.scala
+++ b/src/main/scala/amba/axis/package.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.amba
 
-import freechips.rocketchip.diplomacy._
+import org.chipsalliance.diplomacy.nodes.{InwardNodeHandle, OutwardNodeHandle, NodeHandle}
 
 package object axis
 {

--- a/src/main/scala/amba/package.scala
+++ b/src/main/scala/amba/package.scala
@@ -3,7 +3,8 @@
 package freechips.rocketchip
 
 import chisel3._
-import freechips.rocketchip.util._
+
+import freechips.rocketchip.util.{ControlKey, DataKey, BundleField}
 
 package object amba {
   class AMBAProtBundle extends Bundle {


### PR DESCRIPTION
Updates AMBA to use standalone diplomacy module directly.

Fixes a small issue with builds using chisel source for diplomacy module.